### PR TITLE
Removed Untested Modal Functionality

### DIFF
--- a/src/components/Timer/TaskSelector.js
+++ b/src/components/Timer/TaskSelector.js
@@ -82,7 +82,7 @@ function TaskSelector() {
                 </IconButton>
             }
 
-            <Dialog id="dialog" open={isDialogOpen} onClose={handleCancel} >
+            <Dialog id="dialog" open={isDialogOpen} >
                 <DialogContent>
                     <form>
                         <TextField 

--- a/src/components/Timer/TaskSelector.test.js
+++ b/src/components/Timer/TaskSelector.test.js
@@ -184,4 +184,3 @@ default task are shown", () => {
     const taskText = screen.getByTestId('taskDescription');
     expect(taskText.innerHTML).toMatch(defaultTask);
 })
-

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -5,8 +5,8 @@ import Timer from '../components/Timer/Timer';
 function Home () {
     return (
         <div>
-            <h1>Pomodoro Timer</h1> 
-            <TaskSelector/>
+            <h1>Pomodoro Timer</h1>
+            <center><TaskSelector/></center>
             <Timer/>
         </div>
     )


### PR DESCRIPTION
When the modal is open, clicking off the modal will not cause the modal to close. This decision has been made since we were not able to test it properly.